### PR TITLE
Allow overriding menu depth availability on the Options page via filters

### DIFF
--- a/wds-mega-menus.php
+++ b/wds-mega-menus.php
@@ -89,6 +89,22 @@ class WDS_Mega_Menus {
 	const VERSION = '0.3.0';
 
 	/**
+	 * Constant for overriding the option page depths.
+	 *
+	 * @var   int
+	 * @since 0.3.0
+	 */
+	const OVERRIDE_DEPTH_REQUIRED = 1;
+
+	/**
+	 * Constant for overriding the option page depths.
+	 *
+	 * @var   int
+	 * @since 0.3.0
+	 */
+	const OVERRIDE_DEPTH_DISABLED = 2;
+
+	/**
 	 * URL of plugin directory
 	 *
 	 * @var   string


### PR DESCRIPTION
This PR adds the ability to filter menu options to either force them checked or not allow them to be modified.

``` php
// Force Mega Menu on all menu levels
function force_mm( $overrides ) {
    return WDS_Mega_Menu::OVERRIDE_DEPTH_REQUIRED;
}
add_filter( 'wdsmm_walker_nav_options_depth_override', 'force_mm' );

// Disable every other item
function disable_odd_mm( $overrides, $depth ) {
    if ( $depth % 2 ) {
        return WDS_Mega_Menu::OVERRIDE_DEPTH_DISABLED;
    }

    return false;
}
// etc...
```
